### PR TITLE
fixed dependency of odahuflow module on knative

### DIFF
--- a/terraform/env_types/aws/eks/k8s_setup/main.tf
+++ b/terraform/env_types/aws/eks/k8s_setup/main.tf
@@ -369,6 +369,6 @@ module "odahuflow_helm" {
     secret_name      = module.postgresql.pgsql_credentials["mlflow"].secret
   }
 
-  depends_on = [module.nginx_ingress_helm, module.auth, module.postgresql, module.odahuflow_prereqs, module.vault]
+  depends_on = [module.nginx_ingress_helm, module.auth, module.postgresql, module.odahuflow_prereqs, module.vault, module.knative]
 }
 

--- a/terraform/env_types/azure/aks/k8s_setup/main.tf
+++ b/terraform/env_types/azure/aks/k8s_setup/main.tf
@@ -385,5 +385,5 @@ module "odahuflow_helm" {
     secret_name      = module.postgresql.pgsql_credentials["mlflow"].secret
   }
 
-  depends_on = [module.postgresql, module.odahuflow_prereqs, module.vault, module.nginx_ingress_helm, module.auth]
+  depends_on = [module.postgresql, module.odahuflow_prereqs, module.vault, module.nginx_ingress_helm, module.auth, module.knative]
 }

--- a/terraform/env_types/gcp/gke/k8s_setup/main.tf
+++ b/terraform/env_types/gcp/gke/k8s_setup/main.tf
@@ -395,5 +395,5 @@ module "odahuflow_helm" {
     secret_name      = module.postgresql.pgsql_credentials["mlflow"].secret
   }
 
-  depends_on = [module.postgresql, module.odahuflow_prereqs, module.vault, module.nginx_ingress_helm, module.auth]
+  depends_on = [module.postgresql, module.odahuflow_prereqs, module.vault, module.nginx_ingress_helm, module.auth, module.knative]
 }


### PR DESCRIPTION
Fixing error rises in deploy after migration to Terraform 0.13.4
```
Error: namespaces "knative-serving" not found
  on ../../../../modules/odahuflow/helm/main.tf line 429, in resource "helm_release" "odahuflow":
 429: resource "helm_release" "odahuflow" {
```