### PR TITLE
fix grafana dashboard monitoring namespace dependency

### DIFF
--- a/terraform/modules/k8s/monitoring/main.tf
+++ b/terraform/modules/k8s/monitoring/main.tf
@@ -132,6 +132,7 @@ resource "kubernetes_config_map" "grafana_dashboard" {
   data = {
     "psql-dashboard.json" = file("${path.module}/files/grafana-psql-dashboard.json")
   }
+  depends_on = [kubernetes_namespace.monitoring]
 }
 
 resource "local_file" "grafana_pg_dashboard" {


### PR DESCRIPTION
Fixing error
```
Error: namespaces "kube-monitoring" not found

  on ../../../../modules/k8s/monitoring/main.tf line 120, in resource "kubernetes_config_map" "grafana_dashboard":
 120: resource "kubernetes_config_map" "grafana_dashboard" {
```