### PR TITLE
upgrade istio 1.4 to last patch version

### DIFF
--- a/terraform/modules/k8s/istio/variables.tf
+++ b/terraform/modules/k8s/istio/variables.tf
@@ -10,7 +10,7 @@ variable "tls_secret_key" {
 
 variable "istio_version" {
   type    = string
-  default = "1.4.4"
+  default = "1.4.10"
 }
 
 variable "istio_namespace" {
@@ -39,7 +39,7 @@ variable "docker_password" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://storage.googleapis.com/istio-release/releases/1.4.4/charts"
+  default     = "https://storage.googleapis.com/istio-release/releases/1.4.10/charts"
   description = "URL of used Helm chart repository"
 }
 


### PR DESCRIPTION
Attempt to fix https://github.com/odahu/odahu-flow/issues/455

P.S. istio 1.4.11 is actualy last patch version for 1.4 but I have not found helm repo for it