### PR TITLE
stable charts moved to new location

### DIFF
--- a/terraform/modules/k8s/airflow/main/variables.tf
+++ b/terraform/modules/k8s/airflow/main/variables.tf
@@ -94,7 +94,7 @@ variable "examples_version" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://kubernetes-charts.storage.googleapis.com"
+  default     = "https://charts.helm.sh/stable"
   description = "URL of used Helm chart repository"
 }
 

--- a/terraform/modules/k8s/auth/variables.tf
+++ b/terraform/modules/k8s/auth/variables.tf
@@ -76,7 +76,7 @@ variable "oauth_cookie_secret" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://kubernetes-charts.storage.googleapis.com"
+  default     = "https://charts.helm.sh/stable"
   description = "URL of used Helm chart repository"
 }
 

--- a/terraform/modules/k8s/kube2iam/variables.tf
+++ b/terraform/modules/k8s/kube2iam/variables.tf
@@ -30,7 +30,7 @@ variable "namespace" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://kubernetes-charts.storage.googleapis.com"
+  default     = "https://charts.helm.sh/stable"
   description = "URL of used Helm chart repository"
 }
 

--- a/terraform/modules/k8s/nfs/variables.tf
+++ b/terraform/modules/k8s/nfs/variables.tf
@@ -9,7 +9,7 @@ variable "configuration" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://kubernetes-charts.storage.googleapis.com"
+  default     = "https://charts.helm.sh/stable"
   description = "URL of used Helm chart repository"
 }
 

--- a/terraform/modules/k8s/nginx-ingress/helm/variables.tf
+++ b/terraform/modules/k8s/nginx-ingress/helm/variables.tf
@@ -5,7 +5,7 @@ variable "helm_values" {
 
 variable "helm_repo" {
   type        = string
-  default     = "https://kubernetes-charts.storage.googleapis.com"
+  default     = "https://charts.helm.sh/stable"
   description = "URL of used Helm chart repository"
 }
 


### PR DESCRIPTION
`https://kubernetes-charts.storage.googleapis.com` -> `https://charts.helm.sh/stable`

see https://helm.sh/blog/new-location-stable-incubator-charts/

