### PR TITLE
Disable deny_all policy for airflow web api

### DIFF
--- a/terraform/modules/k8s/airflow/main/templates/airflow.yaml
+++ b/terraform/modules/k8s/airflow/main/templates/airflow.yaml
@@ -43,6 +43,9 @@ airflow:
           key: postgresql-password
 
   config:
+    # https://airflow.apache.org/docs/apache-airflow/stable/security/api.html#disable-authentication
+    # Because we have our own authentication layer
+    AIRFLOW__API__AUTH_BACKEND: "airflow.api.auth.backend.default"
     AIRFLOW__KUBERNETES__RUN_AS_USER: "50000" # Temporary fix for https://github.com/apache/airflow/issues/8564
     AIRFLOW__CORE__LOGGING_LEVEL: DEBUG
     AIRFLOW__CORE__LOAD_EXAMPLES: True


### PR DESCRIPTION
Our robot tests were broken after upgrade airflow up to 1.10.12 because of

Changed in version 1.10.11: In Airflow <1.10.11, the default setting was to allow all API requests without authentication, but this posed security risks for if the Webserver is publicly accessible.

Disable authentication for airflow. Cuz we have own authn layer