### PR TITLE
triton packager. added default values for target connections

### DIFF
--- a/terraform/modules/odahuflow/helm/main.tf
+++ b/terraform/modules/odahuflow/helm/main.tf
@@ -266,9 +266,6 @@ locals {
   packagers = {
     triton = {
       targets = {
-        docker_pull = {
-          default = lookup(local.odahu_docker_creds_connection[0], "id", "")
-        }
         docker_push = {
           default = local.default_model_docker_connection_id
         }


### PR DESCRIPTION
it's needed to create a `docker-triton` packager with default connections for targets (docker-pushl)