### PR TITLE
[#96] Customize GKE logging. 

### DIFF
--- a/terraform/env_types/gcp/gke/gke_create/main.tf
+++ b/terraform/env_types/gcp/gke/gke_create/main.tf
@@ -82,6 +82,7 @@ module "gke_cluster" {
   bastion_gcp_tags       = local.bastion_gcp_tags
   bastion_labels         = var.bastion_labels
   block_project_ssh_key  = var.block_project_ssh_key
+  logging_service        = var.logging_service
 
   depends_on = [
     module.iam,

--- a/terraform/env_types/gcp/gke/gke_create/variables.tf
+++ b/terraform/env_types/gcp/gke/gke_create/variables.tf
@@ -119,6 +119,11 @@ variable "autoscaling_profile" {
   description = "GKE autoscaling profile, possible values: BALANCED|OPTIMIZE_UTILIZATION"
 }
 
+variable "logging_service" {
+  type        = string
+  default     = "logging.googleapis.com/kubernetes"
+  description = "Logging service to write logs to. Possible values: logging.googleapis.com|logging.googleapis.com/kubernetes|none"
+}
 #############
 # Node pool
 #############

--- a/terraform/modules/gcp/gke_cluster/main.tf
+++ b/terraform/modules/gcp/gke_cluster/main.tf
@@ -31,6 +31,7 @@ resource "google_container_cluster" "cluster" {
   # initial number of nodes (minimum 4 per location) and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = local.initial_node_count * 2 >= 4 ? local.initial_node_count * 2 : 4
+  logging_service          = var.logging_service
 
   cluster_autoscaling {
     enabled             = false

--- a/terraform/modules/gcp/gke_cluster/variables.tf
+++ b/terraform/modules/gcp/gke_cluster/variables.tf
@@ -113,6 +113,11 @@ variable "autoscaling_profile" {
   description = "GKE autoscaling profile, possible values: BALANCED|OPTIMIZE_UTILIZATION"
 }
 
+variable "logging_service" {
+  type        = string
+  default     = "none"
+  description = "Logging service to write logs to. Possible values: logging.googleapis.com|logging.googleapis.com/kubernetes|none"
+}
 #############
 # Node pools
 #############


### PR DESCRIPTION
Keep Stackdriver logging for GKE enabled by default. 
closes #96 