### PR TITLE
Elasticsearch index retention fixed

### DIFF
--- a/terraform/modules/k8s/elk/main.tf
+++ b/terraform/modules/k8s/elk/main.tf
@@ -90,7 +90,7 @@ locals {
       "json" = jsonencode({
         "policy" = {
           "phases" = {
-            "hot"    = { "min_age" = "0ms", "actions" = { "rollover" = { "max_size" = try(settings.size, "512MB") } } },
+            "hot"    = { "min_age" = "0ms", "actions" = { "rollover" = { "max_size" = try(settings.size, "512MB"), "max_age" = try(settings.age, "7d") } } },
             "delete" = { "min_age" = try(settings.age, "7d"), "actions" = { "delete" = {} } }
           }
         }


### PR DESCRIPTION
Closes #98 
Fixes actual Elasticsearch index retention process.
Because of old index deletion performing on rotated  index, so we need an aged rollover as an initial step before deletion