### PR TITLE
odahuflow_deployment deletion timeout increased

### DIFF
--- a/terraform/modules/odahuflow/helm/main.tf
+++ b/terraform/modules/odahuflow/helm/main.tf
@@ -394,6 +394,9 @@ resource "kubernetes_namespace" "odahuflow_deployment" {
     }
     name = var.odahuflow_deployment_namespace
   }
+  timeouts {
+    delete = "15m"
+  }
 }
 
 resource "kubernetes_namespace" "odahuflow_batch" {


### PR DESCRIPTION
In some cases default timeout 300s is not enough for resource `odahuflow_helm.kubernetes_namespace.odahuflow_deployment` deletion.